### PR TITLE
feat: rye run startコマンドでボットを起動できるように設定

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -75,7 +75,7 @@ X APIアプリには以下が必要です：
 ### ボットの起動
 
 ```bash
-rye run python -m xpostplanner.bot
+rye run start
 ```
 
 ### 投稿の予約
@@ -147,7 +147,7 @@ XPostPlanner/
 ### 開発モードでの実行
 
 ```bash
-rye run python -m xpostplanner.bot
+rye run start
 ```
 
 ### データベース

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Your X API app needs:
 ### Starting the Bot
 
 ```bash
-rye run python -m xpostplanner.bot
+rye run start
 ```
 
 ### Scheduling a Post
@@ -147,7 +147,7 @@ XPostPlanner/
 ### Running in Development Mode
 
 ```bash
-rye run python -m xpostplanner.bot
+rye run start
 ```
 
 ### Database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "xpostplanner"
 version = "0.1.0"
 description = "Add your description here"
 authors = [
-    { name = "sserada", email = "hirawatasou@gmail.com" }
+    { name = "cacaum", email = "contact.cacaum@gmail.com" }
 ]
 dependencies = [
     "discord-py>=2.5.2",
@@ -21,6 +21,9 @@ build-backend = "hatchling.build"
 [tool.rye]
 managed = true
 dev-dependencies = []
+
+[tool.rye.scripts]
+start = "python -m xpostplanner.bot"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
使いやすさを向上させるため、pyproject.tomlにスクリプト設定を追加
- `[tool.rye.scripts]`セクションを追加
- `start = "python -m xpostplanner.bot"`を設定
- README.mdとREADME-ja.mdの起動方法を更新
- より簡潔で覚えやすいコマンドに変更

変更前: `rye run python -m xpostplanner.bot`
変更後: `rye run start`

Resolves #6

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>